### PR TITLE
Updated: replace flask-oidc==1.4.0 with flask-oidc-ext==1.4.3

### DIFF
--- a/flaskoidc/__init__.py
+++ b/flaskoidc/__init__.py
@@ -5,7 +5,7 @@ from six.moves.urllib.parse import urlencode
 import httplib2
 from flask import redirect, Flask, request, g, current_app
 from flask.helpers import get_env, get_debug_flag
-from flask_oidc import OpenIDConnect, _json_loads
+from flask_oidc_ext import OpenIDConnect, _json_loads
 from flask_session import Session
 from flask_sqlalchemy import SQLAlchemy
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Flask==1.0.2
-flask-oidc==1.4.0
+flask-oidc-ext==1.4.3
 Flask-Session==0.3.2
 Flask-SQLAlchemy==2.4.4


### PR DESCRIPTION
Replace flask-oidc==1.4.0 with flask-oidc-ext==1.4.3, which is actively maintained, and with a lot of bugs fixed.