### PR TITLE
fix: db models

### DIFF
--- a/flaskoidc/models.py
+++ b/flaskoidc/models.py
@@ -15,7 +15,7 @@ class OAuth2Token(app.db.Model):
 
     access_token = Column(String(255), nullable=False)
     expires_in = Column(Integer, default=0)
-    scope = Column(String, default=0)
+    scope = Column(String(255), default=0)
     token_type = Column(String(20))
     refresh_token = Column(String(255))
     expires_at = Column(Integer, default=0)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 
 setup(
     name='flaskoidc',


### PR DESCRIPTION
flaskoidc is missing varchar length for `scope` column which is required by mysql dialect:
![image](https://user-images.githubusercontent.com/5680655/122609568-7e65f580-d07e-11eb-954c-f28f94e6f7db.png)

