### PR TITLE
add FLASK_OIDC prefix to SQLACHEMY_DATABASE_URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ FLASK_OIDC_WHITELISTED_ENDPOINTS: "status,healthcheck,health"
 You can also set the config variables specific to [Flask-SQLAlchemy](https://flask-sqlalchemy.palletsprojects.com/en/2.x/config/) using the same key as the environment variables.
 ```python
 # Details about this below in the "Session Management" section.
-SQLALCHEMY_DATABASE_URI: 'sqlite:///sessions.db'
+FLASK_OIDC_SQLALCHEMY_DATABASE_URI: 'sqlite:///sessions.db'
 ```
 
 ## Known Issues:

--- a/flaskoidc/config.py
+++ b/flaskoidc/config.py
@@ -38,6 +38,6 @@ class BaseConfig(object):
     REDIRECT_URI = os.environ.get('FLASK_OIDC_REDIRECT_URI', '/auth')
     CONFIG_URL = os.environ.get('FLASK_OIDC_CONFIG_URL', '')
 
-    SQLALCHEMY_TRACK_MODIFICATIONS = os.environ.get('SQLALCHEMY_TRACK_MODIFICATIONS', False)
-    SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI", 'sqlite:///sessions.db')
+    SQLALCHEMY_TRACK_MODIFICATIONS = os.environ.get('FLASK_OIDC_SQLALCHEMY_TRACK_MODIFICATIONS', False)
+    SQLALCHEMY_DATABASE_URI = os.environ.get("FLASK_OIDC_SQLALCHEMY_DATABASE_URI", 'sqlite:///sessions.db')
 


### PR DESCRIPTION
Hi,

I'm trying to use amundsen metadata service with mysql instead of neo4j.  SQLACHEMY_DATABASE_URI is used in both libraries, which leads to config conflicts. I suggest adding prefix