### PR TITLE
Forcing https schema for Dockerized environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ _(default: '')_
 
 Client Secret that you get once you create a new application on your OIDC provider.
 
+#### FLASK_OIDC_SCHEMA
+_(default: 'http')_
+
+This must be 'https' in production. Defines the redirection schema returned by _'/login'_
+
 #### FLASK_OIDC_REDIRECT_URI
 _(default: '/auth')_
 

--- a/flaskoidc/__init__.py
+++ b/flaskoidc/__init__.py
@@ -112,7 +112,7 @@ class FlaskOIDC(Flask):
 
         @self.route("/login")
         def login():
-            redirect_uri = url_for("auth", _external=True)
+            redirect_uri = url_for("auth", _external=True, _schema=self.config.get("SCHEMA"))
             return self.auth_client.authorize_redirect(redirect_uri)
 
         @self.route(self.config.get("REDIRECT_URI"))

--- a/flaskoidc/config.py
+++ b/flaskoidc/config.py
@@ -31,6 +31,7 @@ class BaseConfig(object):
     USER_ID_FIELD = os.environ.get("FLASK_OIDC_USER_ID_FIELD", "email")
     CLIENT_ID = os.environ.get("FLASK_OIDC_CLIENT_ID", "")
     CLIENT_SECRET = os.environ.get("FLASK_OIDC_CLIENT_SECRET", "")
+    SCHEMA = os.environ.get("FLASK_OIDC_FORCE_SCHEMA", "http")
     REDIRECT_URI = os.environ.get("FLASK_OIDC_REDIRECT_URI", "/auth")
     OVERWRITE_REDIRECT_URI = os.environ.get("FLASK_OIDC_OVERWRITE_REDIRECT_URI", "/")
     CONFIG_URL = os.environ.get("FLASK_OIDC_CONFIG_URL", "")


### PR DESCRIPTION
Hi @verdan @jacobnosal.

We've been facing an issue when configuring Amundsen
seems like the `redirect_uri` returned by /login is causing the problem
we modified Amundsen's `app_wrapper_class` as a temporal fix
and discussed scaling the solution to the level of `flaskoidc` as the best approach for further integrations


This is the fix in Amundsen:

<img width="862" alt="Captura de Pantalla 2021-11-25 a la(s) 9 36 40 p  m" src="https://user-images.githubusercontent.com/45695858/144355468-bb8cc01e-5359-460a-84db-eead828378f6.png">