### PR TITLE
Fixing url_for() attribute for scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,10 @@ _(default: '')_
 
 Client Secret that you get once you create a new application on your OIDC provider.
 
-
-#### FLASK_OIDC_FORCE_SCHEMA
+#### FLASK_OIDC_FORCE_SCHEME
 _(default: 'http')_
 
-This must be 'https' in production. Defines the redirection schema returned by _'/login'_
+Can be used to force a URL scheme when crafting a `redirect_uri` in _'/login'_ route.  Useful when Flask application is behind an ingress doing TLS termination.
 
 #### FLASK_OIDC_REDIRECT_URI
 _(default: '/auth')_

--- a/flaskoidc/__init__.py
+++ b/flaskoidc/__init__.py
@@ -112,7 +112,7 @@ class FlaskOIDC(Flask):
 
         @self.route("/login")
         def login():
-            redirect_uri = url_for("auth", _external=True, _schema=self.config.get("SCHEMA"))
+            redirect_uri = url_for("auth", _external=True, _scheme=self.config.get("SCHEME"))
             return self.auth_client.authorize_redirect(redirect_uri)
 
         @self.route(self.config.get("REDIRECT_URI"))

--- a/flaskoidc/config.py
+++ b/flaskoidc/config.py
@@ -31,7 +31,7 @@ class BaseConfig(object):
     USER_ID_FIELD = os.environ.get("FLASK_OIDC_USER_ID_FIELD", "email")
     CLIENT_ID = os.environ.get("FLASK_OIDC_CLIENT_ID", "")
     CLIENT_SECRET = os.environ.get("FLASK_OIDC_CLIENT_SECRET", "")
-    SCHEMA = os.environ.get("FLASK_OIDC_FORCE_SCHEMA", "http")
+    SCHEME = os.environ.get("FLASK_OIDC_FORCE_SCHEME", "http")
     REDIRECT_URI = os.environ.get("FLASK_OIDC_REDIRECT_URI", "/auth")
     OVERWRITE_REDIRECT_URI = os.environ.get("FLASK_OIDC_OVERWRITE_REDIRECT_URI", "/")
     CONFIG_URL = os.environ.get("FLASK_OIDC_CONFIG_URL", "")


### PR DESCRIPTION
There was a "typo" in the previous PR.  Wasn't really a typo since it was `schema` all over the place, but the important piece is the attribute in `url_for()` is `_scheme` and not `_schema`.  When using `_schema`, it becomes an extra parameter in the URL returned, which has no effect on the URL scheme (HTTP vs HTTPS).  I have reflected that fix also in the documentation as well as in the env variables. 