### PR TITLE
Option to go back to orignal url after sucessful login

### DIFF
--- a/flaskoidc/__init__.py
+++ b/flaskoidc/__init__.py
@@ -150,11 +150,11 @@ class FlaskOIDC(Flask):
                 if redirectUrl:
                     return redirect(redirectUrl)
                 url = request.cookies.get("failed_authentication_url")
-                resp = redirect(url | "")
                 if url:
+                    resp = redirect(url)
                     redirectUrl = url
-                    resp.set_cookie("failed_authentication_url", "", expires=datetime.datetime.now())
-                return resp
+                    return resp.set_cookie("failed_authentication_url", "", expires=datetime.datetime.now())
+                return redirect("")
             except Exception as ex:
                 LOGGER.exception(ex)
                 raise ex


### PR DESCRIPTION
The default behavior remains the same (redirect to FLASK_OIDC_OVERWRITE_REDIRECT_URI after login). When FLASK_OIDC_OVERWRITE_REDIRECT_URI is set to an empty string, however, the user is redirected to the url he/she was trying to visit when authentication was required