### PR TITLE
Upgrade Authlib to version 1.x

### DIFF
--- a/flaskoidc/__init__.py
+++ b/flaskoidc/__init__.py
@@ -188,7 +188,7 @@ class FlaskOIDC(Flask):
     def _update_token(self, name, token, refresh_token=None, access_token=None):
         from flaskoidc.models import OAuth2Token
 
-        LOGGER.debug(f"Calling _update_token(token={token}...")
+        LOGGER.debug(f"Calling _update_token")
         try:
             token = self.auth_client.fetch_access_token(refresh_token=refresh_token, grant_type="refresh_token")
             return OAuth2Token.update_tokens(
@@ -196,7 +196,7 @@ class FlaskOIDC(Flask):
             )
         except Exception:
             LOGGER.exception(
-                f"Exception occurred _update_token(token={token}...", exc_info=True
+                f"Exception occurred _update_token", exc_info=True
             )
             raise LoginRequiredError("_update_token: Couldn't update the token")
 

--- a/flaskoidc/__init__.py
+++ b/flaskoidc/__init__.py
@@ -149,9 +149,8 @@ class FlaskOIDC(Flask):
 
         @self.route("/logout")
         def logout():
-            # ToDo: Think of if we should delete the session entity or not
-            # if session.get("user"):
-            #     OAuth2Token.delete(name=_provider, user_id=session["user"]["__id"])
+            if session.get("user"):
+                OAuth2Token.delete(name=_provider, user_id=session["user"]["__id"])
             session.pop("user", None)
             return redirect(url_for("login"))
 

--- a/flaskoidc/__init__.py
+++ b/flaskoidc/__init__.py
@@ -198,6 +198,7 @@ class FlaskOIDC(Flask):
             LOGGER.exception(
                 f"Exception occurred _update_token(token={token}...", exc_info=True
             )
+            raise LoginRequiredError("_update_token: Couldn't update the token")
 
     def _fetch_token(self, name):
         from flaskoidc.models import OAuth2Token

--- a/flaskoidc/__init__.py
+++ b/flaskoidc/__init__.py
@@ -211,9 +211,14 @@ class FlaskOIDC(Flask):
             token_dict = token.to_token()
             _current_time = round(time.time())
             if token_dict["expires_at"] <= _current_time:
-                token_with_refresh_token = OAuth2Token.get_with_refresh_token(name=name, user_id=user_id).to_token()
-                return self._update_token(name, token_with_refresh_token, token_with_refresh_token["refresh_token"],
-                                          token_with_refresh_token["access_token"])
+                token_with_refresh_token = OAuth2Token.get_with_refresh_token(name=name, user_id=user_id)
+                if token_with_refresh_token is None:
+                    LOGGER.info("Refresh token could not be found, redirecting to login")
+                    raise LoginRequiredError
+                token_with_refresh_token_dict = token_with_refresh_token.to_token()
+                return self._update_token(name, token_with_refresh_token_dict,
+                                          token_with_refresh_token_dict["refresh_token"],
+                                          token_with_refresh_token_dict["access_token"])
             return token_dict
         except KeyError:
             LOGGER.info("User not found in the session, redirecting to login")

--- a/flaskoidc/__init__.py
+++ b/flaskoidc/__init__.py
@@ -128,7 +128,7 @@ class FlaskOIDC(Flask):
             ]
             try:
                 token = self.auth_client.authorize_access_token()
-                user = self.auth_client.parse_id_token(token)
+                user = self.auth_client.parse_id_token(token, token.get('nonce'))
                 user_id = user.get(self.config.get("USER_ID_FIELD"))
                 if not user_id:
                     raise BadRequest(

--- a/flaskoidc/__init__.py
+++ b/flaskoidc/__init__.py
@@ -3,6 +3,7 @@ import logging
 
 import time
 from authlib.integrations.flask_client import OAuth
+from authlib.oidc.core.errors import LoginRequiredError
 from flask import redirect, Flask, request, session, abort
 from flask.helpers import get_env, get_debug_flag, url_for
 from flask_sqlalchemy import SQLAlchemy
@@ -85,11 +86,11 @@ class FlaskOIDC(Flask):
             )
 
         with self.app_context():
-            from flaskoidc.models import OAuth2Token, _fetch_token, _update_token
+            from flaskoidc.models import OAuth2Token
 
             self.db.create_all()
 
-            oauth = OAuth(self, fetch_token=_fetch_token, update_token=_update_token)
+            oauth = OAuth(self, fetch_token=self._fetch_token, update_token=self._update_token)
 
             self.auth_client = oauth.register(
                 name=_provider,
@@ -183,3 +184,41 @@ class FlaskOIDC(Flask):
 
                 defaults[key] = value
         return self.config_class(root_path, defaults)
+
+    def _update_token(self, name, token, refresh_token=None, access_token=None):
+        from flaskoidc.models import OAuth2Token
+
+        LOGGER.debug(f"Calling _update_token(token={token}...")
+        try:
+            token = self.auth_client.fetch_access_token(refresh_token=refresh_token, grant_type="refresh_token")
+            return OAuth2Token.update_tokens(
+                name, token, refresh_token=refresh_token, access_token=access_token
+            )
+        except Exception:
+            LOGGER.exception(
+                f"Exception occurred _update_token(token={token}...", exc_info=True
+            )
+
+    def _fetch_token(self, name):
+        from flaskoidc.models import OAuth2Token
+
+        try:
+            user_id = session["user"]["__id"]
+            LOGGER.debug(f"Calling _fetch_token(name={name},user_id={user_id})...")
+
+            token = OAuth2Token.get(name=name, user_id=user_id)
+            if not token:
+                raise LoginRequiredError("_fetch_token: No Token Found")
+            token_dict = token.to_token()
+            _current_time = round(time.time())
+            if token_dict["expires_at"] <= _current_time:
+                token_with_refresh_token = OAuth2Token.get_with_refresh_token(name=name, user_id=user_id).to_token()
+                return self._update_token(name, token_with_refresh_token, token_with_refresh_token["refresh_token"],
+                                          token_with_refresh_token["access_token"])
+            return token_dict
+        except KeyError:
+            LOGGER.info("User not found in the session, redirecting to login")
+            raise LoginRequiredError
+        except Exception:
+            LOGGER.error("Unexpected Error", exc_info=True)
+            raise LoginRequiredError

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 requirements = [
     "Flask>=1.0.2",
-    "Authlib>1.0.0,<2.0.0",
+    "Authlib>=1.0.0,<2.0.0",
     "requests>=2.25.1",
     "Flask-SQLAlchemy>=2.5.1",
 ]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 requirements = [
     "Flask>=1.0.2",
-    "Authlib>=0.15.4,<1.0.0",
+    "Authlib>1.0.0,<2.0.0",
     "requests>=2.25.1",
     "Flask-SQLAlchemy>=2.5.1",
 ]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 requirements = [
     "Flask>=1.0.2",
-    "Authlib>=0.15.4",
+    "Authlib>=0.15.4,<1.0.0",
     "requests>=2.25.1",
     "Flask-SQLAlchemy>=2.5.1",
 ]


### PR DESCRIPTION
This PR upgrades the Authlib dependency to v1.x to fixed the following issue:
https://github.com/lepture/authlib/issues/334

Additionally, it adds the logic to handle the cases where refresh token does not exist in the storage. This potentially fixes the issue https://github.com/verdan/flaskoidc/issues/28